### PR TITLE
Add basic Nginx panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+nginx_conf
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# custompanel
+# Custom Panel
+
+A minimal Flask-based web panel for managing Nginx server blocks on Ubuntu.
+
+## Features
+
+- List existing server block configurations.
+- Add new domains with document roots.
+- Remove domains.
+- Reload Nginx after changes.
+
+This panel stores configuration files in the `nginx_conf` directory by default.
+It also maintains an `enabled` directory that simulates the `sites-enabled`
+folder used by Nginx.
+
+## Installation
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the panel:
+   ```bash
+   python panel.py
+   ```
+
+The panel will be available at `http://localhost:8080`.
+
+**Note**: Reloading Nginx requires sudo privileges. If running locally, ensure
+your user has permission to reload the Nginx service.
+

--- a/panel.py
+++ b/panel.py
@@ -1,0 +1,78 @@
+import os
+import subprocess
+from flask import Flask, request, redirect, url_for, render_template_string
+
+app = Flask(__name__)
+
+CONF_DIR = os.environ.get('CONF_DIR', 'nginx_conf')
+ENABLED_DIR = os.environ.get('ENABLED_DIR', os.path.join(CONF_DIR, 'enabled'))
+
+os.makedirs(CONF_DIR, exist_ok=True)
+os.makedirs(ENABLED_DIR, exist_ok=True)
+
+SITE_TEMPLATE = """
+server {
+    listen 80;
+    server_name {domain};
+    root {root};
+}
+"""
+
+INDEX_TEMPLATE = """
+<!doctype html>
+<html>
+<head><title>Nginx Panel</title></head>
+<body>
+<h1>Nginx Panel</h1>
+<h2>Sites</h2>
+<ul>
+{% for site in sites %}
+<li>{{ site }} - <a href="{{ url_for('remove_site', name=site) }}">Remove</a></li>
+{% endfor %}
+</ul>
+<h2>Add site</h2>
+<form action="{{ url_for('add_site') }}" method="post">
+Domain: <input type="text" name="domain">
+Root: <input type="text" name="root">
+<input type="submit" value="Add">
+</form>
+</body>
+</html>
+"""
+
+@app.route('/')
+def index():
+    sites = sorted(os.listdir(CONF_DIR))
+    return render_template_string(INDEX_TEMPLATE, sites=sites)
+
+@app.route('/add', methods=['POST'])
+def add_site():
+    domain = request.form['domain']
+    root = request.form['root']
+    conf_path = os.path.join(CONF_DIR, domain)
+    if os.path.exists(conf_path):
+        return 'Site already exists', 400
+    with open(conf_path, 'w') as f:
+        f.write(SITE_TEMPLATE.format(domain=domain, root=root))
+    symlink = os.path.join(ENABLED_DIR, domain)
+    if not os.path.exists(symlink):
+        os.symlink(conf_path, symlink)
+    reload_nginx()
+    return redirect(url_for('index'))
+
+@app.route('/remove/<name>')
+def remove_site(name):
+    conf_path = os.path.join(CONF_DIR, name)
+    symlink = os.path.join(ENABLED_DIR, name)
+    if os.path.islink(symlink):
+        os.unlink(symlink)
+    if os.path.exists(conf_path):
+        os.remove(conf_path)
+    reload_nginx()
+    return redirect(url_for('index'))
+
+def reload_nginx():
+    subprocess.run(['sudo', 'systemctl', 'reload', 'nginx'], check=False)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+pytest

--- a/test_panel.py
+++ b/test_panel.py
@@ -1,0 +1,25 @@
+import os
+import panel
+
+
+def setup_module(module):
+    panel.app.config['TESTING'] = True
+    panel.CONF_DIR = os.path.join(os.getcwd(), 'test_conf')
+    panel.ENABLED_DIR = os.path.join(panel.CONF_DIR, 'enabled')
+    os.makedirs(panel.CONF_DIR, exist_ok=True)
+    os.makedirs(panel.ENABLED_DIR, exist_ok=True)
+
+
+def teardown_module(module):
+    import shutil
+    shutil.rmtree(panel.CONF_DIR)
+
+
+def test_add_and_remove():
+    client = panel.app.test_client()
+    resp = client.post('/add', data={'domain': 'example.com', 'root': '/var/www'})
+    assert resp.status_code == 302
+    assert os.path.exists(os.path.join(panel.CONF_DIR, 'example.com'))
+    resp = client.get('/remove/example.com')
+    assert resp.status_code == 302
+    assert not os.path.exists(os.path.join(panel.CONF_DIR, 'example.com'))


### PR DESCRIPTION
## Summary
- create a simple Flask-based Nginx management panel
- add a test showing the panel can add and remove a site
- document install and usage steps
- ignore runtime directories

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6851162ef668832ab06ee4442aacdcaf